### PR TITLE
feat(course-swap): improve SwapCard UI and add Gmail contact button

### DIFF
--- a/src/components/course-swap/SwapCard.jsx
+++ b/src/components/course-swap/SwapCard.jsx
@@ -163,7 +163,7 @@ const SwapCard = ({ swap, courses = [], onDelete, onMarkComplete }) => {
           </div>
           
           {/* Action Buttons */}
-          {isOwner && (
+          {isOwner ? (
             <div className="flex gap-2">
               {!swap.isDone && (
                 <Button 
@@ -182,23 +182,20 @@ const SwapCard = ({ swap, courses = [], onDelete, onMarkComplete }) => {
                 <Trash2 className="w-4 h-4" />
               </Button>
             </div>
+          ) : swap.uEmail && (
+            <Button
+              size="sm"
+              onClick={() => {
+                const courseInfo = giveCourse ? `${giveCourse.courseCode}-${giveCourse.sectionName} (${giveCourse.faculties || 'TBA'})` : `Section ${swap.getSectionId}`;
+                window.open(`https://mail.google.com/mail/?view=cm&to=${swap.uEmail}&su=Course Swap Request - ${encodeURIComponent(courseInfo)}`, '_blank');
+              }}
+              className="gap-2 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white"
+              title="Contact via Gmail"
+            >
+              Send <Mail className="w-4 h-4" />
+            </Button>
           )}
         </div>
-        
-        {/* Contact Button for non-owners */}
-        {!isOwner && swap.uEmail && (
-          <Button
-            size="sm"
-            onClick={() => {
-              const courseInfo = giveCourse ? `${giveCourse.courseCode}-${giveCourse.sectionName} (${giveCourse.faculties || 'TBA'})` : `Section ${swap.getSectionId}`;
-              window.open(`https://mail.google.com/mail/?view=cm&to=${swap.uEmail}&su=Course Swap Request - ${encodeURIComponent(courseInfo)}`, '_blank');
-            }}
-            className="w-full gap-2 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white font-medium transition-all shadow-sm hover:shadow-md"
-          >
-            <Mail className="w-4 h-4" />
-            Contact via Gmail
-          </Button>
-        )}
       </CardContent>
       
       {/* Hover Tooltip for "Looking For" Courses */}


### PR DESCRIPTION

- Fix faculty display to use **initials** instead of **non-existent _employeeName_** (Faculty Names)
- Add Contact via Gmail button for non-owners with course info in subject
- Improved _hoveredCourses_ button: It's now a bit larger, easier to see and now includes faculty intial

<img width="1533" height="425" alt="Screenshot 2026-02-09 195241" src="https://github.com/user-attachments/assets/4eb9fde7-5f03-4a64-896c-131212c4e952" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/268c68b6-0628-432f-b8b0-b16cdddf3039" />
