### PR TITLE
fix(course_swap): Hoverable course information in the offering section

### DIFF
--- a/src/components/course-swap/SwapCard.jsx
+++ b/src/components/course-swap/SwapCard.jsx
@@ -80,7 +80,24 @@ const SwapCard = ({ swap, courses = [], onDelete, onMarkComplete }) => {
                 Offering
               </span>
             </div>
-            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
+            {/* I am working here */}
+            <div 
+              className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-200"
+              onMouseEnter={(e) => {
+                if (giveCourse) {
+                  setHoveredCourse(giveCourse);
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  const viewportWidth = window.innerWidth;
+                  const tooltipWidth = 384;
+                  const shouldShowLeft = rect.right + tooltipWidth + 10 > viewportWidth;
+                  setTooltipPosition({ 
+                    x: shouldShowLeft ? rect.left - tooltipWidth - 10 : rect.right + 10, 
+                    y: rect.top 
+                  });
+                }
+              }}
+              onMouseLeave={() => setHoveredCourse(null)}
+            >
               <p className="font-bold text-lg text-gray-900 dark:text-white">
                 {giveCourse ? formatCourse(giveCourse) : `Section ${swap.getSectionId}`}
               </p>


### PR DESCRIPTION
Hovering over the **offered course** card in the Swap Card section now shows the extended information of the offered course. This PR is directed to solve #29 

<img width="903" height="545" alt="image" src="https://github.com/user-attachments/assets/e8158633-79bf-48b6-88a0-db8dd4b9fdd9" />
