### PR TITLE
feat: Added Export PNG Button Component for Routine Pages

### DIFF
--- a/src/app/(dashboard)/dashboard/preprereg/page.jsx
+++ b/src/app/(dashboard)/dashboard/preprereg/page.jsx
@@ -1011,7 +1011,7 @@ const PreRegistrationPage = () => {
                   <Save className="w-4 h-4" />
                   {savingRoutine ? 'Saving...' : 'Save Routine'}
                 </button>
-                <ExportRoutinePNG selectedCourses={enrichedSelectedCourses} routineRef={routineRef} />
+                <ExportRoutinePNG courses={enrichedSelectedCourses} routineRef={routineRef} filename="routine" />
                 <button
                   onClick={() => setShowRoutineModal(false)}
                   className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"

--- a/src/app/(dashboard)/dashboard/savedRoutines/page.jsx
+++ b/src/app/(dashboard)/dashboard/savedRoutines/page.jsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { toast } from 'sonner';
-import * as htmlToImage from 'html-to-image';
+import { exportRoutineToPNG } from '@/components/routine/ExportRoutinePNG';
 
 const SavedRoutinesPage = () => {
   const { data: session } = useSession();
@@ -565,63 +565,10 @@ const SavedRoutinesPage = () => {
         return;
       }
 
-      if (!routineRef?.current) {
-        toast.error('Routine table not found');
-        return;
-      }
-
-      try {
-        const originalRoutineSegment = routineRef.current;
-        if (!originalRoutineSegment) return;
-
-        const scrolledWidth = 1800; // ! FORCE a standard desktop width- Change to increase downloaded image's width
-
-        // ? Hidden container for the cloned routine segment
-        const container = document.createElement('div');
-        container.style.position = 'absolute';
-        container.style.top = '-9999px';
-        container.style.left = '-9999px';
-        container.style.width = scrolledWidth + 'px';
-
-        container.style.zoom = 0.5;
-
-        document.body.appendChild(container);
-
-        // ? Cloning the Routine Segment
-        const clonedRoutine = originalRoutineSegment.cloneNode(true);
-
-        // ? Force the clonedRoutine to show everything and adjust to desktop resolution
-        clonedRoutine.style.width = scrolledWidth + 'px';
-        clonedRoutine.style.height = 'auto';
-        clonedRoutine.style.overflow = 'visible';
-
-        container.appendChild(clonedRoutine);
-
-        // ? We are waiting here, because our browser can be stuipidly dumb (And also slow ¯\_(ツ)_/¯)
-        // ? which causes html-to-image to capture the image before styles are even applied, resulting in a broken image
-        await new Promise(resolve => setTimeout(resolve, 100));
-
-        const dataUrl = await htmlToImage.toPng(clonedRoutine, {
-          quality: 0.95,
-          pixelRatio: 3, // ! Higher number -> Higher resolution -> Larger file size (Maybe add a slider on client side for them to adjust this in the future?)
-          backgroundColor: '#111827',
-          width: scrolledWidth,
-          height: clonedRoutine.scrollHeight,
-        });
-
-        // ? Anhilation of the cloned routine and resetting styles back to normal
-        document.body.removeChild(container);
-
-        const link = document.createElement('a');
-        link.download = `merged-routine-${new Date().toISOString().split('T')[0]}.png`;
-        link.href = dataUrl;
-        link.click();
-
-        toast.success('Routine exported successfully!');
-      } catch (error) {
-        console.error('Error exporting routine:', error);
-        toast.error('Failed to export routine.');
-      }
+      await exportRoutineToPNG({
+        routineRef,
+        filename: 'saved-routine',
+      });
     };
 
     return (
@@ -729,63 +676,10 @@ const SavedRoutinesPage = () => {
         return;
       }
 
-      if (!routineRef?.current) {
-        toast.error('Routine table not found');
-        return;
-      }
-
-      try {
-        const originalRoutineSegment = routineRef.current;
-        if (!originalRoutineSegment) return;
-
-        const scrolledWidth = 1800; // ! FORCE a standard desktop width- Change to increase downloaded image's width
-
-        // ? Hidden container for the cloned routine segment
-        const container = document.createElement('div');
-        container.style.position = 'absolute';
-        container.style.top = '-9999px';
-        container.style.left = '-9999px';
-        container.style.width = scrolledWidth + 'px';
-
-        container.style.zoom = 0.5;
-
-        document.body.appendChild(container);
-
-        // ? Cloning the Routine Segment
-        const clonedRoutine = originalRoutineSegment.cloneNode(true);
-
-        // ? Force the clonedRoutine to show everything and adjust to desktop resolution
-        clonedRoutine.style.width = scrolledWidth + 'px';
-        clonedRoutine.style.height = 'auto';
-        clonedRoutine.style.overflow = 'visible';
-
-        container.appendChild(clonedRoutine);
-
-        // ? We are waiting here, because our browser can be stuipidly dumb (And also slow ¯\_(ツ)_/¯)
-        // ? which causes html-to-image to capture the image before styles are even applied, resulting in a broken image
-        await new Promise(resolve => setTimeout(resolve, 100));
-
-        const dataUrl = await htmlToImage.toPng(clonedRoutine, {
-          quality: 0.95,
-          pixelRatio: 3, // ! Higher number -> Higher resolution -> Larger file size (Maybe add a slider on client side for them to adjust this in the future?)
-          backgroundColor: '#111827',
-          width: scrolledWidth,
-          height: clonedRoutine.scrollHeight,
-        });
-
-        // ? Anhilation of the cloned routine and resetting styles back to normal
-        document.body.removeChild(container);
-
-        const link = document.createElement('a');
-        link.download = `merged-routine-${new Date().toISOString().split('T')[0]}.png`;
-        link.href = dataUrl;
-        link.click();
-
-        toast.success('Routine exported successfully!');
-      } catch (error) {
-        console.error('Error exporting routine:', error);
-        toast.error('Failed to export routine.');
-      }
+      await exportRoutineToPNG({
+        routineRef,
+        filename: 'merged-routine',
+      });
     };
 
     return (

--- a/src/app/(main)/merged-routine/[id]/page.jsx
+++ b/src/app/(main)/merged-routine/[id]/page.jsx
@@ -4,7 +4,7 @@ import { Calendar, Download, RefreshCw, AlertCircle, Copy, Check, Save, Users, X
 import CourseHoverTooltip from '@/components/ui/CourseHoverTooltip';
 import { useParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import * as htmlToImage from 'html-to-image';
+import { exportRoutineToPNG } from '@/components/routine/ExportRoutinePNG';
 
 const SharedMergedRoutinePage = () => {
     const { id } = useParams();
@@ -220,43 +220,11 @@ const SharedMergedRoutinePage = () => {
     const exportToPNG = async () => {
         if (!courses || courses.length === 0 || !routineRef?.current) return;
 
-        try {
-            const originalRoutineSegment = routineRef.current;
-            const scrolledWidth = 1800;
-
-            const container = document.createElement('div');
-            container.style.position = 'absolute';
-            container.style.top = '-9999px';
-            container.style.left = '-9999px';
-            container.style.width = scrolledWidth + 'px';
-            container.style.zoom = 0.5;
-            document.body.appendChild(container);
-
-            const clonedRoutine = originalRoutineSegment.cloneNode(true);
-            clonedRoutine.style.width = scrolledWidth + 'px';
-            clonedRoutine.style.height = 'auto';
-            clonedRoutine.style.overflow = 'visible';
-            container.appendChild(clonedRoutine);
-
-            await new Promise(resolve => setTimeout(resolve, 100));
-
-            const dataUrl = await htmlToImage.toPng(clonedRoutine, {
-                quality: 0.95,
-                pixelRatio: 3,
-                backgroundColor: '#111827',
-                width: scrolledWidth,
-                height: clonedRoutine.scrollHeight,
-            });
-
-            document.body.removeChild(container);
-
-            const link = document.createElement('a');
-            link.download = `shared-merged-routine-${id.slice(0, 8)}-${new Date().toISOString().split('T')[0]}.png`;
-            link.href = dataUrl;
-            link.click();
-        } catch (error) {
-            console.error('Error exporting routine:', error);
-        }
+        await exportRoutineToPNG({
+            routineRef,
+            filename: `shared-merged-routine-${id.slice(0, 8)}`,
+            showToast: false,
+        });
     };
 
     // Loading state

--- a/src/app/(main)/routine/[id]/page.jsx
+++ b/src/app/(main)/routine/[id]/page.jsx
@@ -4,7 +4,7 @@ import { Calendar, Download, RefreshCw, AlertCircle, Copy, Check, Save } from 'l
 import { useParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import RoutineTableGrid from '@/components/routine/RoutineTableGrid';
-import * as htmlToImage from 'html-to-image';
+import { exportRoutineToPNG } from '@/components/routine/ExportRoutinePNG';
 
 const SharedRoutinePage = () => {
     const { id } = useParams();
@@ -110,43 +110,11 @@ const SharedRoutinePage = () => {
     const exportToPNG = async () => {
         if (!courses || courses.length === 0 || !routineRef?.current) return;
 
-        try {
-            const originalRoutineSegment = routineRef.current;
-            const scrolledWidth = 1800;
-
-            const container = document.createElement('div');
-            container.style.position = 'absolute';
-            container.style.top = '-9999px';
-            container.style.left = '-9999px';
-            container.style.width = scrolledWidth + 'px';
-            container.style.zoom = 0.5;
-            document.body.appendChild(container);
-
-            const clonedRoutine = originalRoutineSegment.cloneNode(true);
-            clonedRoutine.style.width = scrolledWidth + 'px';
-            clonedRoutine.style.height = 'auto';
-            clonedRoutine.style.overflow = 'visible';
-            container.appendChild(clonedRoutine);
-
-            await new Promise(resolve => setTimeout(resolve, 100));
-
-            const dataUrl = await htmlToImage.toPng(clonedRoutine, {
-                quality: 0.95,
-                pixelRatio: 3,
-                backgroundColor: '#111827',
-                width: scrolledWidth,
-                height: clonedRoutine.scrollHeight,
-            });
-
-            document.body.removeChild(container);
-
-            const link = document.createElement('a');
-            link.download = `shared-routine-${id.slice(0, 8)}-${new Date().toISOString().split('T')[0]}.png`;
-            link.href = dataUrl;
-            link.click();
-        } catch (error) {
-            console.error('Error exporting routine:', error);
-        }
+        await exportRoutineToPNG({
+            routineRef,
+            filename: `shared-routine-${id.slice(0, 8)}`,
+            showToast: false,
+        });
     };
 
     // Loading state

--- a/src/components/routine/ExportRoutinePNG.jsx
+++ b/src/components/routine/ExportRoutinePNG.jsx
@@ -1,65 +1,183 @@
 // ExportRoutinePNG.jsx
 'use client';
-import React from 'react';
+import React, { useCallback } from 'react';
 import * as htmlToImage from 'html-to-image';
-// Install with: npm install html-to-image
 import { toast } from 'sonner';
 
-const ExportRoutinePNG = ({ selectedCourses, routineRef, displayToast }) => {
-  const exportToPNG = async () => {
-    if (!selectedCourses || selectedCourses.length === 0) {
-      toast.error('Please select some courses first');
-      return;
+// ! Default export settings - can be customized per use case
+const DEFAULT_EXPORT_OPTIONS = {
+  width: 1800,           // ? Desktop width for consistent exports
+  pixelRatio: 3,         // ? Higher = better quality, larger file
+  quality: 0.95,
+  backgroundColor: '#111827',
+  zoom: 0.5,
+  waitTime: 100,         // ? Wait for styles to apply
+};
+
+// ! Core export function - handles all the PNG export logic
+// ? Takes a ref to a routine element, clones it into a hidden container,
+// ? renders it at a fixed desktop width for consistency, then triggers download.
+// ? Options: routineRef, filename, showToast, width, pixelRatio, backgroundColor, onSuccess, onError
+export const exportRoutineToPNG = async ({
+  routineRef,
+  filename = 'routine',
+  showToast = true,
+  width = DEFAULT_EXPORT_OPTIONS.width,
+  pixelRatio = DEFAULT_EXPORT_OPTIONS.pixelRatio,
+  quality = DEFAULT_EXPORT_OPTIONS.quality,
+  backgroundColor = DEFAULT_EXPORT_OPTIONS.backgroundColor,
+  zoom = DEFAULT_EXPORT_OPTIONS.zoom,
+  waitTime = DEFAULT_EXPORT_OPTIONS.waitTime,
+  onSuccess,
+  onError,
+}) => {
+  if (!routineRef?.current) {
+    if (showToast) toast.error('Routine table not found');
+    onError?.('Routine table not found');
+    return false;
+  }
+
+  const originalRoutineSegment = routineRef.current;
+
+  // ? Hidden container for the cloned routine segment
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.top = '-9999px';
+  container.style.left = '-9999px';
+  container.style.width = `${width}px`;
+  container.style.zoom = zoom;
+  document.body.appendChild(container);
+
+  // ? Cloning the Routine Segment
+  const clonedRoutine = originalRoutineSegment.cloneNode(true);
+
+  // ? Force the clonedRoutine to show everything and adjust to desktop resolution
+  clonedRoutine.style.width = `${width}px`;
+  clonedRoutine.style.height = 'auto';
+  clonedRoutine.style.overflow = 'visible';
+  container.appendChild(clonedRoutine);
+
+  try {
+    // ? We are waiting here, because our browser can be stupidly dumb (And also slow ¯\_(ツ)_/¯)
+    // ? which causes html-to-image to capture the image before styles are even applied, resulting in a broken image
+    await new Promise(resolve => setTimeout(resolve, waitTime));
+
+    const dataUrl = await htmlToImage.toPng(clonedRoutine, {
+      quality,
+      pixelRatio, // ! Higher number -> Higher resolution -> Larger file size
+      backgroundColor,
+      width,
+      height: clonedRoutine.scrollHeight,
+    });
+
+    // ? Annihilation of the cloned routine
+    document.body.removeChild(container);
+
+    // ? Trigger download
+    const link = document.createElement('a');
+    link.download = `${filename}-${new Date().toISOString().split('T')[0]}.png`;
+    link.href = dataUrl;
+    link.click();
+
+    if (showToast) toast.success('Routine exported successfully!');
+    onSuccess?.();
+    return true;
+  } catch (error) {
+    console.error('Error exporting routine:', error);
+    
+    // ? Cleanup on error
+    if (container.parentNode) {
+      document.body.removeChild(container);
+    }
+    
+    if (showToast) toast.error('Failed to export routine.');
+    onError?.(error);
+    return false;
+  }
+};
+
+// ! React Hook for exporting routine as PNG with validation and loading state
+// ? Wraps exportRoutineToPNG with course validation and isExporting state management.
+// ? Use this when you need to track export progress or validate courses before export.
+// ? Returns: { exportToPNG, isExporting }
+export const useExportRoutinePNG = ({
+  routineRef,
+  courses = [],
+  filename = 'routine',
+  showValidationErrors = true,
+  ...exportOptions
+} = {}) => {
+  const [isExporting, setIsExporting] = React.useState(false);
+
+  const exportToPNG = useCallback(async () => {
+    // ? Validation - ensure we have courses to export
+    if (!courses || courses.length === 0) {
+      if (showValidationErrors) toast.error('No courses to export');
+      return false;
     }
 
     if (!routineRef?.current) {
-      toast.error('Routine table not found');
-      return;
-      return;
+      if (showValidationErrors) toast.error('Routine table not found');
+      return false;
     }
 
-    if (!routineRef?.current) {
-      toast.error('Routine table not found');
-      return;
-    }
-
+    setIsExporting(true);
+    
     try {
-      // Using html-to-image to capture the actual visible routine table
-      const dataUrl = await htmlToImage.toPng(routineRef.current, {
-        quality: 0.95,
-        pixelRatio: 2,
-        backgroundColor: '#111827',
-        style: {
-          transform: 'scale(1)',
-          transformOrigin: 'top left',
-        }
+      const result = await exportRoutineToPNG({
+        routineRef,
+        filename,
+        ...exportOptions,
       });
-      
-      // Download the image
-      const link = document.createElement('a');
-      link.download = `routine-${new Date().toISOString().split('T')[0]}.png`;
-      link.href = dataUrl;
-      link.click();
-      
-      if (displayToast) {
-        displayToast('Routine exported successfully!', 'success');
-      }
-      
-    } catch (error) {
-      console.error('Error exporting to PNG:', error);
-      toast.error('Failed to export routine as PNG. Please try again.');
+      return result;
+    } finally {
+      setIsExporting(false);
     }
-  };
+  }, [routineRef, courses, filename, showValidationErrors, exportOptions]);
+
+  return { exportToPNG, isExporting };
+};
+
+// ? Download Icon SVG Component
+const DownloadIcon = ({ className = "w-4 h-4" }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path 
+      strokeLinecap="round" 
+      strokeLinejoin="round" 
+      strokeWidth={2} 
+      d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" 
+    />
+  </svg>
+);
+
+// ! The same Export PNG Button Component which has been used a thousands of times :v
+// ? Drop-in button that handles validation, loading state, and export.
+// ? Props: routineRef, courses, filename, label, className, showIcon, disabled
+const ExportRoutinePNG = ({ 
+  routineRef, 
+  courses = [],
+  filename = 'routine',
+  label = 'Save as PNG',
+  className = '',
+  showIcon = true,
+  disabled = false,
+  ...exportOptions
+}) => {
+  const { exportToPNG, isExporting } = useExportRoutinePNG({
+    routineRef,
+    courses,
+    filename,
+    ...exportOptions,
+  });
   
   return (
     <button
       onClick={exportToPNG}
-      className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg flex items-center gap-2 transition-colors text-white"
+      disabled={disabled || isExporting}
+      className={`px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed rounded-lg flex items-center gap-2 transition-colors text-white ${className}`}
     >
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-      </svg>
-      Save as PNG
+      {showIcon && <DownloadIcon />}
+      {isExporting ? 'Exporting...' : label}
     </button>
   );
 };


### PR DESCRIPTION
# Changes:
- Made a reusable Export PNG Button Component that can be used across all routine-related pages.
- Replaces the previous export buttons with this new component

# Verifying:
- View/Make a routine then download from (On 80% Zoom, 100% Zoom, 140% Zoom, 180% Zoom, 200% Zoom)
  - PrePreReg Page 
  - Saved Routine Page
  - Merge Routine Page
  
 # Issue:
 This solves #43 